### PR TITLE
Use Trans component to translate and format error message

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -371,6 +371,7 @@
   "access.users": "Users",
   "access.usersInGroup": "Users in group",
   "access.usersInGroup.view": "View users in group",
+  "acm.logs.error": "Red Hat Advanced Cluster Management version 2.10 and newer requires the <code>cluster-proxy</code> and <code>managed-serviceaccount</code> add-ons to retrieve logs. Make sure that these add-ons are enabled on the hub cluster.",
   "acm.plugin.not.ready": "The <bold>Red Hat Advanced Cluster Management for Kubernetes</bold> operator is installed, but the console plugin is not available. If you just completed the installation procedure within the last few minutes, wait a few moments for a web console update alert to appear. Click the link in the alert to refresh the web console to the latest version.",
   "acm.plugin.not.ready.tips": "If the alert does not appear, confirm that a <code>MultiClusterHub</code> resource has been created and is available, and that the <code>acm</code> console plugin is enabled.",
   "Action": "Action",

--- a/frontend/src/routes/Home/Search/Details/LogsPage.tsx
+++ b/frontend/src/routes/Home/Search/Details/LogsPage.tsx
@@ -14,11 +14,10 @@ import {
 } from '@patternfly/react-core'
 import { CompressIcon, DownloadIcon, ExpandIcon, OutlinedWindowRestoreIcon } from '@patternfly/react-icons'
 import { LogViewer } from '@patternfly/react-log-viewer'
-import { Dispatch, MutableRefObject, SetStateAction, useEffect, useMemo, useRef, useState } from 'react'
+import { Dispatch, MutableRefObject, ReactNode, SetStateAction, useEffect, useMemo, useRef, useState } from 'react'
 import screenfull from 'screenfull'
-import { useTranslation } from '../../../../lib/acm-i18next'
-import { DOC_BASE_PATH } from '../../../../lib/doc-util'
-import { fetchRetry, getBackendUrl, ManagedCluster } from '../../../../resources'
+import { Trans, useTranslation } from '../../../../lib/acm-i18next'
+import { fetchRetry, getBackendUrl } from '../../../../resources'
 import { useRecoilValue, useSharedAtoms } from '../../../../shared-recoil'
 import { AcmAlert, AcmLoadingPage } from '../../../../ui-components'
 import { LogViewerSearch } from './LogsViewerSearch'
@@ -297,7 +296,7 @@ export default function LogsPage(props: {
   const { t } = useTranslation()
   const [isLoadingLogs, setIsLoadingLogs] = useState<boolean>(false)
   const [logs, setLogs] = useState<string>('')
-  const [logsError, setLogsError] = useState<string>()
+  const [logsError, setLogsError] = useState<ReactNode>()
   const [container, setContainer] = useState<string>(sessionStorage.getItem(`${name}-${cluster}-container`) || '')
 
   const [showJumpToBottomBtn, setShowJumpToBottomBtn] = useState<boolean>(false)
@@ -373,9 +372,7 @@ export default function LogsPage(props: {
         })
         .catch((err) => {
           if (err.code === 400) {
-            setLogsError(
-              `Red Hat Advanced Cluster Management requires `cluster-proxy-addon` and the `managed-serviceaccount` add-on to retrieve logs from 2.10. Make sure that these add-ons are enabled on the hub cluster.`
-            )
+            setLogsError(<Trans i18nKey="acm.logs.error" components={{ code: <code /> }} />)
           } else {
             setLogsError(err.message)
           }


### PR DESCRIPTION
@zhiweiyin318 Here is an example of how to use the `<Trans>` component and include formatting. If you have a documentation link to include (which I still think would be ideal) you can find examples in the code of how to do that with this component.

I did edit the message a bit to include "2.10 or newer" as Oliver suggested, and I changed `cluster-proxy-addon` to `cluster-proxy` because I saw there is a `ClusterManagementAddOn` with that name... is that what this refers to? I am not sure about `managed-serviceaccount`. Also, it mentions enabling these on the hub, but is there anything to do to managed clusters, or will the add-ons automatically be applied there if enabled on the hub?

<img width="1401" alt="image" src="https://github.com/zhiweiyin318/console/assets/42188127/4324b6cc-4e88-4114-b7b9-8ae47ede283a">
